### PR TITLE
chore: update npm scripts for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npx next start",
     "lint": "npx next lint",
     "express": "nodemon src/app/api/server.js",
-    "postinstall": "npm install --legacy-peer-deps"
+    "vercel-build": "npm install --legacy-peer-deps && npm run build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+    "version": 2,
+    "builds": [
+      {
+        "src": "package.json",
+        "use": "@vercel/node"
+      }
+    ],
+    "buildCommand": "npm run vercel-build"
+}


### PR DESCRIPTION
- Added "vercel-build" script to install dependencies and run build before deployment
- Replaced "postinstall" script with "vercel-build" in package.json